### PR TITLE
Fix storage and todo list bugs

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -255,6 +255,7 @@ function addTask() {
 
     
 };
+addTask();
 //On click of the submit button this function calls the addTask function to execute its role
 addItemButton.addEventListener("click", function() {
     addTask();
@@ -268,7 +269,8 @@ addItemButton.addEventListener("click", function() {
 
 //Clears the list by clearing local storage
 clearList.addEventListener("click", function(){
-    localStorage.clear()
+    localStorage.removeItem("allTasks");
+    localStorage.removeItem("task");
     window.location.reload();
 })
 


### PR DESCRIPTION
Todo list no longer clears all local storage when the clear button is used. Added a hotfix so that the todo list displays without having to add something to it.